### PR TITLE
Extend dark theme backgrounds to tab components

### DIFF
--- a/app/(drawer)/(tabs)/_layout.tsx
+++ b/app/(drawer)/(tabs)/_layout.tsx
@@ -20,6 +20,9 @@ export default function TabLayout() {
         headerShown: false,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,
+        sceneContainerStyle: {
+          backgroundColor: colors.background.primary,
+        },
         tabBarStyle: {
           backgroundColor: colors.surface.primary,
           borderTopColor:

--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -1,10 +1,16 @@
 import { ChatScreen } from "@/components/Chat/ChatScreen";
+import { useTheme } from "@/hooks/useColorScheme";
 import React from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function HomeScreen() {
+  const { colors } = useTheme();
+
   return (
-    <SafeAreaView className="flex-1 bg-background dark:bg-background-dark">
+    <SafeAreaView
+      className="flex-1"
+      style={{ backgroundColor: colors.background.primary }}
+    >
       <ChatScreen />
     </SafeAreaView>
   );

--- a/app/(drawer)/(tabs)/inventory.tsx
+++ b/app/(drawer)/(tabs)/inventory.tsx
@@ -1,16 +1,25 @@
+import { useTheme } from "@/hooks/useColorScheme";
 import React from "react";
 import { ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function InventoryScreen() {
+  const { colors } = useTheme();
+
   return (
-    <SafeAreaView className="flex-1 bg-background dark:bg-background-dark">
+    <SafeAreaView
+      className="flex-1"
+      style={{ backgroundColor: colors.background.primary }}
+    >
       <View className="flex-1 px-4 pt-4">
         <Text className="text-text dark:text-text-dark text-xl font-bold mb-4 text-center">
           Inventory
         </Text>
         <ScrollView className="flex-1">
-          <View className="bg-surface dark:bg-surface-dark rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary">
+          <View
+            className="rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary"
+            style={{ backgroundColor: colors.surface.secondary }}
+          >
             <Text className="text-text dark:text-text-dark text-lg font-semibold mb-2">
               Equipment
             </Text>
@@ -18,7 +27,10 @@ export default function InventoryScreen() {
               No items yet
             </Text>
           </View>
-          <View className="bg-surface dark:bg-surface-dark rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary">
+          <View
+            className="rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary"
+            style={{ backgroundColor: colors.surface.secondary }}
+          >
             <Text className="text-text dark:text-text-dark text-lg font-semibold mb-2">
               Consumables
             </Text>
@@ -26,7 +38,10 @@ export default function InventoryScreen() {
               No items yet
             </Text>
           </View>
-          <View className="bg-surface dark:bg-surface-dark rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary">
+          <View
+            className="rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary"
+            style={{ backgroundColor: colors.surface.secondary }}
+          >
             <Text className="text-text dark:text-text-dark text-lg font-semibold mb-2">
               Treasure
             </Text>

--- a/app/(drawer)/(tabs)/settings.tsx
+++ b/app/(drawer)/(tabs)/settings.tsx
@@ -9,7 +9,10 @@ export default function SettingsScreen() {
   const { colors } = useTheme();
 
   return (
-    <SafeAreaView className="flex-1 bg-background dark:bg-background-dark">
+    <SafeAreaView
+      className="flex-1"
+      style={{ backgroundColor: colors.background.primary }}
+    >
       <View className="flex-1 px-4 pt-4">
         <Text className="text-text dark:text-text-dark text-xl font-bold mb-4 text-center">
           Settings
@@ -17,7 +20,10 @@ export default function SettingsScreen() {
         <ScrollView className="flex-1">
           <ThemeToggle />
 
-          <View className="mt-4 bg-surface dark:bg-surface-dark rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary">
+          <View
+            className="mt-4 rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary"
+            style={{ backgroundColor: colors.surface.secondary }}
+          >
             <Text className="text-text dark:text-text-dark text-lg font-semibold mb-4">
               Game Settings
             </Text>
@@ -41,7 +47,10 @@ export default function SettingsScreen() {
             </TouchableOpacity>
           </View>
 
-          <View className="bg-surface dark:bg-surface-dark rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary">
+          <View
+            className="rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary"
+            style={{ backgroundColor: colors.surface.secondary }}
+          >
             <Text className="text-text dark:text-text-dark text-lg font-semibold mb-4">
               Account
             </Text>
@@ -77,7 +86,10 @@ export default function SettingsScreen() {
             </TouchableOpacity>
           </View>
 
-          <View className="bg-surface dark:bg-surface-dark rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary">
+          <View
+            className="rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary"
+            style={{ backgroundColor: colors.surface.secondary }}
+          >
             <Text className="text-text dark:text-text-dark text-lg font-semibold mb-4">
               About
             </Text>

--- a/app/(drawer)/(tabs)/stats.tsx
+++ b/app/(drawer)/(tabs)/stats.tsx
@@ -1,16 +1,25 @@
+import { useTheme } from "@/hooks/useColorScheme";
 import React from "react";
 import { ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function StatsScreen() {
+  const { colors } = useTheme();
+
   return (
-    <SafeAreaView className="flex-1 bg-background dark:bg-background-dark">
+    <SafeAreaView
+      className="flex-1"
+      style={{ backgroundColor: colors.background.primary }}
+    >
       <View className="flex-1 px-4 pt-4">
         <Text className="text-text dark:text-text-dark text-xl font-bold mb-4 text-center">
           Stats
         </Text>
         <ScrollView className="flex-1">
-          <View className="bg-surface dark:bg-surface-dark rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary">
+          <View
+            className="rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary"
+            style={{ backgroundColor: colors.surface.secondary }}
+          >
             <Text className="text-text dark:text-text-dark text-lg font-semibold mb-2">
               Character Stats
             </Text>
@@ -53,7 +62,10 @@ export default function StatsScreen() {
               </View>
             </View>
           </View>
-          <View className="bg-surface dark:bg-surface-dark rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary">
+          <View
+            className="rounded-lg p-4 mb-4 border border-border-primary dark:border-border-secondary"
+            style={{ backgroundColor: colors.surface.secondary }}
+          >
             <Text className="text-text dark:text-text-dark text-lg font-semibold mb-2">
               Combat Stats
             </Text>

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -30,15 +30,26 @@ export function ChatInput({
 
   return (
     <View
-      className="flex-row items-center px-4 py-4 bg-surface dark:bg-surface-dark border-t border-border-primary dark:border-border-secondary"
-      style={{ paddingBottom: insets.bottom > 0 ? insets.bottom + 12 : 0 }}
+      className="flex-row items-center px-4 py-4"
+      style={{
+        backgroundColor: colors.surface.primary,
+        borderTopColor: colors.border.secondary,
+        borderTopWidth: 1,
+        paddingBottom: insets.bottom > 0 ? insets.bottom + 12 : 0,
+      }}
     >
       <TextInput
         value={message}
         onChangeText={setMessage}
         placeholder={placeholder}
         placeholderTextColor={colors.text.tertiary}
-        className="flex-1 bg-surface-secondary dark:bg-surface-dark text-text dark:text-text-dark px-4 py-3 rounded-full border border-border-secondary dark:border-border-primary mr-3"
+        className="flex-1 px-4 py-3 rounded-full mr-3"
+        style={{
+          backgroundColor: colors.surface.secondary,
+          borderColor: colors.border.secondary,
+          borderWidth: 1,
+          color: colors.text.primary,
+        }}
         multiline
         maxLength={500}
         editable={!disabled}

--- a/components/Chat/ChatMessage.tsx
+++ b/components/Chat/ChatMessage.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from "@/hooks/useColorScheme";
 import React from "react";
 import { Text, View } from "react-native";
 
@@ -8,6 +9,8 @@ interface ChatMessageProps {
 }
 
 export function ChatMessage({ message, isAI, timestamp }: ChatMessageProps) {
+  const { colors } = useTheme();
+
   return (
     <View
       className={`flex-row ${isAI ? "justify-center" : "justify-end"} mb-3`}
@@ -15,9 +18,17 @@ export function ChatMessage({ message, isAI, timestamp }: ChatMessageProps) {
       <View
         className={`max-w-[80%] px-4 py-3 rounded-2xl ${
           isAI
-            ? "bg-surface-secondary dark:bg-surface-dark border border-border-secondary"
+            ? "border"
             : "bg-primary-600 dark:bg-primary-500 border border-primary-500 dark:border-primary-400"
         }`}
+        style={
+          isAI
+            ? {
+                backgroundColor: colors.surface.secondary,
+                borderColor: colors.border.secondary,
+              }
+            : undefined
+        }
       >
         <Text
           className={`text-sm ${

--- a/components/Chat/ChatScreen.tsx
+++ b/components/Chat/ChatScreen.tsx
@@ -39,14 +39,20 @@ export function ChatScreen() {
   };
 
   return (
-    <View className="flex-1 bg-background dark:bg-background-dark">
+    <View
+      className="flex-1"
+      style={{ backgroundColor: colors.background.primary }}
+    >
       {/* Floating menu button (disabled when drawer is open) */}
       <TouchableOpacity
         accessibilityLabel="Open menu"
         disabled={isDrawerOpen}
         onPress={() => navigation.dispatch(DrawerActions.toggleDrawer())}
-        className="absolute top-3 left-3 w-9 h-9 rounded-full bg-surface-secondary dark:bg-surface-dark items-center justify-center z-10"
-        style={{ opacity: isDrawerOpen ? 0.5 : 1 }}
+        className="absolute top-3 left-3 w-9 h-9 rounded-full items-center justify-center z-10"
+        style={{
+          backgroundColor: colors.surface.secondary,
+          opacity: isDrawerOpen ? 0.5 : 1,
+        }}
       >
         <Entypo name="menu" size={18} color={colors.text.secondary} />
       </TouchableOpacity>
@@ -77,7 +83,10 @@ export function ChatScreen() {
           ))}
 
           {isLoading && (
-            <View className="flex-row items-center space-x-2 p-4 bg-surface-secondary dark:bg-surface-dark rounded-lg mt-2">
+            <View
+              className="flex-row items-center space-x-2 p-4 rounded-lg mt-2"
+              style={{ backgroundColor: colors.surface.secondary }}
+            >
               <ActivityIndicator size="small" color={colors.primary[500]} />
               <Text className="text-text-secondary dark:text-text-tertiary text-sm">
                 Dungeon Master is thinking...

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -17,7 +17,10 @@ export function ThemeToggle() {
   ];
 
   return (
-    <View className="p-4 bg-surface dark:bg-surface-dark rounded-lg border border-border-primary dark:border-border-secondary">
+    <View
+      className="p-4 rounded-lg border border-border-primary dark:border-border-secondary"
+      style={{ backgroundColor: colors.surface.secondary }}
+    >
       <Text className="text-text dark:text-text-dark font-semibold text-lg mb-3">
         Theme
       </Text>
@@ -29,8 +32,16 @@ export function ThemeToggle() {
             className={`flex-row items-center justify-between p-3 rounded-lg border ${
               themeMode === option.mode
                 ? "bg-primary-100 border-primary-300 dark:bg-primary-900/40 dark:border-primary-500"
-                : "bg-surface-secondary dark:bg-surface-dark border-border-secondary dark:border-border-primary"
+                : "border-border-secondary dark:border-border-primary"
             }`}
+            style={
+              themeMode === option.mode
+                ? undefined
+                : {
+                    backgroundColor: colors.surface.secondary,
+                    borderColor: colors.border.secondary,
+                  }
+            }
           >
             <View className="flex-row items-center space-x-3">
               <Ionicons
@@ -72,7 +83,8 @@ export function QuickThemeToggle() {
   return (
     <TouchableOpacity
       onPress={toggleTheme}
-      className="p-2 rounded-full bg-surface-secondary dark:bg-surface-dark border border-border-primary dark:border-border-secondary"
+      className="p-2 rounded-full border border-border-primary dark:border-border-secondary"
+      style={{ backgroundColor: colors.surface.secondary }}
     >
       <Ionicons
         name={colorScheme === "dark" ? "sunny" : "moon"}


### PR DESCRIPTION
## Summary
- restyle tab screen cards with the theme surface color so dark mode components use a lighter onyx background
- update chat controls and theme toggle to pull from the shared surface palette for consistent dark styling

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68dde597de6c832085a59979d3d24051